### PR TITLE
feat: add rpi4 uboot and sd-image

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -91,6 +91,23 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.pyfdt --print-build-logs
+  x86_64-linux---sd-aarch64-rpi4:
+    name: x86_64-linux.sd-aarch64-rpi4
+    runs-on:
+      - ubuntu-latest
+    needs:
+      - x86_64-linux---uboot-aarch64-rpi4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.sd-aarch64-rpi4 --print-build-logs
   x86_64-linux---seL4-deps:
     name: x86_64-linux.seL4-deps
     runs-on:
@@ -546,6 +563,22 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-x86_64-x86_64-simulate --print-build-logs
+  x86_64-linux---uboot-aarch64-rpi4:
+    name: x86_64-linux.uboot-aarch64-rpi4
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.uboot-aarch64-rpi4 --print-build-logs
   x86_64-linux---uboot-armv7l-zynq-zc702:
     name: x86_64-linux.uboot-armv7l-zynq-zc702
     runs-on:

--- a/pkgs/seL4-test.nix
+++ b/pkgs/seL4-test.nix
@@ -21,7 +21,7 @@ stdenvNoLibs.mkDerivation rec {
   src = fetchGoogleRepoTool {
     url = "https://github.com/seL4/sel4test-manifest.git";
     rev = version;
-    hash = "sha256-s0VBUX6dX4GJJ2wU/8yCD1Vksr8aFm98xC+jt1uWM84=";
+    hash = "sha256-aPMSys7KgQ3J0MkHfD9Gxbg1GRBXv7UcoPYCP1py6bw=";
     latestCommitTimestamp = "2024-03-25";
   };
 


### PR DESCRIPTION
This commit adds uboot and sd-image derivations for the RaspberryPi 4. This is to maximize on-boarding speed as per the seL4 docs: https://docs.sel4.systems/Hardware/Rpi4.html