### PR TITLE
fix: normalize the way seL4-kernel.nix is written

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -139,6 +139,38 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.crossStdenvArmv7lOldBintools --print-build-logs
+  x86_64-linux---packages---crossStdenvRiscv32:
+    name: x86_64-linux---packages---crossStdenvRiscv32
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.crossStdenvRiscv32 --print-build-logs
+  x86_64-linux---packages---crossStdenvRiscv64:
+    name: x86_64-linux---packages---crossStdenvRiscv64
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.crossStdenvRiscv64 --print-build-logs
   x86_64-linux---packages---crossStdenvi686:
     name: x86_64-linux---packages---crossStdenvi686
     runs-on:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -434,6 +434,25 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-deps --print-build-logs
+  x86_64-linux---packages---seL4-kernel-aarch64:
+    name: x86_64-linux---packages---seL4-kernel-aarch64
+    runs-on:
+      - ubuntu-latest
+    needs:
+      - x86_64-linux---packages---guardonce
+      - x86_64-linux---packages---pyfdt
+      - x86_64-linux---packages---seL4-deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.seL4-kernel-aarch64 --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm:
     name: x86_64-linux---packages---seL4-kernel-arm
     runs-on:
@@ -460,7 +479,6 @@ jobs:
     needs:
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
-      - x86_64-linux---packages---seL4-deps
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -472,6 +490,44 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-hyp --print-build-logs
+  x86_64-linux---packages---seL4-kernel-arm-hyp-exynos5:
+    name: x86_64-linux---packages---seL4-kernel-arm-hyp-exynos5
+    runs-on:
+      - ubuntu-latest
+    needs:
+      - x86_64-linux---packages---guardonce
+      - x86_64-linux---packages---pyfdt
+      - x86_64-linux---packages---seL4-deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.seL4-kernel-arm-hyp-exynos5 --print-build-logs
+  x86_64-linux---packages---seL4-kernel-arm-imx8mm:
+    name: x86_64-linux---packages---seL4-kernel-arm-imx8mm
+    runs-on:
+      - ubuntu-latest
+    needs:
+      - x86_64-linux---packages---guardonce
+      - x86_64-linux---packages---pyfdt
+      - x86_64-linux---packages---seL4-deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.seL4-kernel-arm-imx8mm --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm-mcs:
     name: x86_64-linux---packages---seL4-kernel-arm-mcs
     runs-on:

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
           #
           microkit-sdk = pkgs.microkit-sdk;
 
+
           #
           ### Linux
           #
@@ -136,12 +137,24 @@
           #
           ### seL4 verified kernel flavours
           #
+          seL4-kernel-aarch64 = pkgsCrossAarch64.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "AARCH64_verified";
+          };
+
+          seL4-kernel-arm-hyp-exynos5 = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "ARM_HYP_exynos5_verified";
+          };
+
           seL4-kernel-arm-hyp = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
             verifiedConfig = "ARM_HYP_verified";
           };
 
           seL4-kernel-arm-mcs = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
             verifiedConfig = "ARM_MCS_verified";
+          };
+
+          seL4-kernel-arm-imx8mm = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "ARM_imx8mm_verified";
           };
 
           seL4-kernel-arm = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
@@ -159,6 +172,7 @@
           seL4-kernel-x64 = pkgsCrossx86_64.callPackage pkgs/seL4-kernel.nix {
             verifiedConfig = "X64_verified";
           };
+
 
           #
           ### seL4 kernel + userspace flavours

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,18 @@
           crossSystem.config = "x86_64-unknown-linux-musl";
           overlays = [ self.overlays.default ];
         });
+
+        pkgsCrossRiscv32 = (import nixpkgs {
+          inherit system;
+          crossSystem.config = "riscv32-unknown-none-elf";
+          overlays = [ self.overlays.default ];
+        });
+
+        pkgsCrossRiscv64 = (import nixpkgs {
+          inherit system;
+          crossSystem.config = "riscv64-unknown-none-elf";
+          overlays = [ self.overlays.default ];
+        });
       in
       {
         packages = {
@@ -68,6 +80,8 @@
           crossStdenvArmv7lOldBintools = pkgsCrossArmv7lOldBintools.stdenvNoLibs;
           crossStdenvi686 = pkgsCrossi686.stdenvNoLibs;
           crossStdenvx86_64 = pkgsCrossx86_64.stdenvNoLibs;
+          crossStdenvRiscv32 = pkgsCrossRiscv32.stdenvNoLibs;
+          crossStdenvRiscv64 = pkgsCrossRiscv64.stdenvNoLibs;
 
 
           #
@@ -120,30 +134,30 @@
 
 
           #
-          ### seL4 Kernel Flavours
+          ### seL4 verified kernel flavours
           #
-          seL4-kernel-arm-hyp = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "ARM_HYP_verified";
+          seL4-kernel-arm-hyp = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "ARM_HYP_verified";
           };
 
-          seL4-kernel-arm-mcs = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "ARM_MCS_verified";
+          seL4-kernel-arm-mcs = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "ARM_MCS_verified";
           };
 
-          seL4-kernel-arm = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "ARM_verified";
+          seL4-kernel-arm = pkgsCrossArmv7l.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "ARM_verified";
           };
 
-          seL4-kernel-riscv64-mcs = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "RISCV64_MCS_verified";
+          seL4-kernel-riscv64-mcs = pkgsCrossRiscv64.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "RISCV64_MCS_verified";
           };
 
-          seL4-kernel-riscv64 = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "RISCV64_verified";
+          seL4-kernel-riscv64 = pkgsCrossRiscv64.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "RISCV64_verified";
           };
 
-          seL4-kernel-x64 = pkgs.callPackage pkgs/seL4-kernel.nix {
-            config = "X64_verified";
+          seL4-kernel-x64 = pkgsCrossx86_64.callPackage pkgs/seL4-kernel.nix {
+            verifiedConfig = "X64_verified";
           };
 
           #

--- a/pkgs/seL4-kernel.nix
+++ b/pkgs/seL4-kernel.nix
@@ -26,6 +26,8 @@ let
     "RISCV64_verified"
     "X64_verified"
   ] ++ extraVerifiedConfigs;
+
+  brokenVerifiedConfigs = [ "ARM_HYP_exynos5_verified" "ARM_HYP_verified" ];
 in
 
 # check that the passed seL4 config is known
@@ -61,6 +63,14 @@ stdenv.mkDerivation rec {
     "-DCROSS_COMPILER_PREFIX=${stdenv.cc.targetPrefix}"
     "-DCMAKE_TOOLCHAIN_FILE=../gcc.cmake"
   ] ++ lib.lists.optional (verifiedConfig != null) "-C../configs/${verifiedConfig}.cmake";
+
+  # TODO remove hotfix for https://github.com/seL4/seL4/issues/1334
+  installPhase = lib.strings.optionalString (lib.lists.elem verifiedConfig brokenVerifiedConfigs)
+    ''
+      runHook preInstall
+      ninja install || true
+      runHook postInstall
+    '';
 
   dontFixup = true;
 }

--- a/pkgs/seL4-kernel.nix
+++ b/pkgs/seL4-kernel.nix
@@ -16,8 +16,11 @@
 let
   # known seL4 configs
   knownVerifiedConfigs = [
+    "AARCH64_verified"
+    "ARM_HYP_exynos5_verified"
     "ARM_HYP_verified"
     "ARM_MCS_verified"
+    "ARM_imx8mm_verified"
     "ARM_verified"
     "RISCV64_MCS_verified"
     "RISCV64_verified"


### PR DESCRIPTION
This makes it easier to override/inject `seL4-kernel.nix`. Also, it enables build of non-verified platforms with less effort.