### PR TITLE
fix: linux-aarch64 nitpicks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,8 @@
             #
             # nix develop .\#linux-aarch64.menuconfigShell
 
-            #kernel = linuxManualConfig {
-            #  inherit (pkgsCrossAarch64,linuxPackages.kernel) version src;
+            #kernel = pkgsCrossAarch64.linuxManualConfig {
+            #  inherit (pkgsCrossAarch64.linuxPackages.kernel) version src;
             #  configfile = ./.config;
             #};
           };


### PR DESCRIPTION
- Introduce assert to ensure menuconfigShell runs for the correct kernel version
- Fix typo in manual config example
- Be specific with the cd to linux-${kernel.version}