### PR TITLE
refactor: remove need for oldBintools

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   x86_64-linux---packages---atf-aarch64-zcu102:
-    name: x86_64-linux---packages---atf-aarch64-zcu102
+    name: atf-aarch64-zcu102
     runs-on:
       - ubuntu-latest
     needs: []
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.atf-aarch64-zcu102 --print-build-logs
   x86_64-linux---packages---camkes-deps:
-    name: x86_64-linux---packages---camkes-deps
+    name: camkes-deps
     runs-on:
       - ubuntu-latest
     needs:
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.camkes-deps --print-build-logs
   x86_64-linux---packages---capDL-tool:
-    name: x86_64-linux---packages---capDL-tool
+    name: capDL-tool
     runs-on:
       - ubuntu-latest
     needs: []
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.capDL-tool --print-build-logs
   x86_64-linux---packages---concurrencytest:
-    name: x86_64-linux---packages---concurrencytest
+    name: concurrencytest
     runs-on:
       - ubuntu-latest
     needs: []
@@ -76,7 +76,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.concurrencytest --print-build-logs
   x86_64-linux---packages---guardonce:
-    name: x86_64-linux---packages---guardonce
+    name: guardonce
     runs-on:
       - ubuntu-latest
     needs: []
@@ -92,7 +92,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.guardonce --print-build-logs
   x86_64-linux---packages---linux-aarch64:
-    name: x86_64-linux---packages---linux-aarch64
+    name: linux-aarch64
     runs-on:
       - ubuntu-latest
     needs: []
@@ -108,7 +108,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.linux-aarch64 --print-build-logs
   x86_64-linux---packages---microkit-sdk:
-    name: x86_64-linux---packages---microkit-sdk
+    name: microkit-sdk
     runs-on:
       - ubuntu-latest
     needs:
@@ -125,7 +125,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.microkit-sdk --print-build-logs
   x86_64-linux---packages---pmufw-mblaze-zcu102:
-    name: x86_64-linux---packages---pmufw-mblaze-zcu102
+    name: pmufw-mblaze-zcu102
     runs-on:
       - ubuntu-latest
     needs: []
@@ -141,7 +141,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.pmufw-mblaze-zcu102 --print-build-logs
   x86_64-linux---packages---pyfdt:
-    name: x86_64-linux---packages---pyfdt
+    name: pyfdt
     runs-on:
       - ubuntu-latest
     needs: []
@@ -157,7 +157,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.pyfdt --print-build-logs
   x86_64-linux---packages---sd-aarch64-rpi4:
-    name: x86_64-linux---packages---sd-aarch64-rpi4
+    name: sd-aarch64-rpi4
     runs-on:
       - ubuntu-latest
     needs:
@@ -174,7 +174,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.sd-aarch64-rpi4 --print-build-logs
   x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-qemu-arm-virt:
-    name: x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-qemu-arm-virt
+    name: seL4-camkes-vm-examples-aarch64-qemu-arm-virt
     runs-on:
       - ubuntu-latest
     needs:
@@ -197,7 +197,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-camkes-vm-examples-aarch64-qemu-arm-virt --print-build-logs
   x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-tx1:
-    name: x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-tx1
+    name: seL4-camkes-vm-examples-aarch64-tx1
     runs-on:
       - ubuntu-latest
     needs:
@@ -220,7 +220,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-camkes-vm-examples-aarch64-tx1 --print-build-logs
   x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-tx2:
-    name: x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-tx2
+    name: seL4-camkes-vm-examples-aarch64-tx2
     runs-on:
       - ubuntu-latest
     needs:
@@ -243,7 +243,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-camkes-vm-examples-aarch64-tx2 --print-build-logs
   x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-zcu102:
-    name: x86_64-linux---packages---seL4-camkes-vm-examples-aarch64-zcu102
+    name: seL4-camkes-vm-examples-aarch64-zcu102
     runs-on:
       - ubuntu-latest
     needs:
@@ -266,7 +266,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-camkes-vm-examples-aarch64-zcu102 --print-build-logs
   x86_64-linux---packages---seL4-camkes-vm-examples-armv7l-exynos5422:
-    name: x86_64-linux---packages---seL4-camkes-vm-examples-armv7l-exynos5422
+    name: seL4-camkes-vm-examples-armv7l-exynos5422
     runs-on:
       - ubuntu-latest
     needs:
@@ -289,7 +289,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-camkes-vm-examples-armv7l-exynos5422 --print-build-logs
   x86_64-linux---packages---seL4-deps:
-    name: x86_64-linux---packages---seL4-deps
+    name: seL4-deps
     runs-on:
       - ubuntu-latest
     needs:
@@ -307,7 +307,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-deps --print-build-logs
   x86_64-linux---packages---seL4-kernel-aarch64:
-    name: x86_64-linux---packages---seL4-kernel-aarch64
+    name: seL4-kernel-aarch64
     runs-on:
       - ubuntu-latest
     needs:
@@ -326,7 +326,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-aarch64 --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm:
-    name: x86_64-linux---packages---seL4-kernel-arm
+    name: seL4-kernel-arm
     runs-on:
       - ubuntu-latest
     needs:
@@ -345,7 +345,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm-hyp:
-    name: x86_64-linux---packages---seL4-kernel-arm-hyp
+    name: seL4-kernel-arm-hyp
     runs-on:
       - ubuntu-latest
     needs:
@@ -364,7 +364,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-hyp --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm-hyp-exynos5:
-    name: x86_64-linux---packages---seL4-kernel-arm-hyp-exynos5
+    name: seL4-kernel-arm-hyp-exynos5
     runs-on:
       - ubuntu-latest
     needs:
@@ -383,7 +383,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-hyp-exynos5 --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm-imx8mm:
-    name: x86_64-linux---packages---seL4-kernel-arm-imx8mm
+    name: seL4-kernel-arm-imx8mm
     runs-on:
       - ubuntu-latest
     needs:
@@ -402,7 +402,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-imx8mm --print-build-logs
   x86_64-linux---packages---seL4-kernel-arm-mcs:
-    name: x86_64-linux---packages---seL4-kernel-arm-mcs
+    name: seL4-kernel-arm-mcs
     runs-on:
       - ubuntu-latest
     needs:
@@ -421,7 +421,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-mcs --print-build-logs
   x86_64-linux---packages---seL4-kernel-riscv64-elf:
-    name: x86_64-linux---packages---seL4-kernel-riscv64-elf
+    name: seL4-kernel-riscv64-elf
     runs-on:
       - ubuntu-latest
     needs:
@@ -440,7 +440,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-riscv64-elf --print-build-logs
   x86_64-linux---packages---seL4-kernel-riscv64-mcs:
-    name: x86_64-linux---packages---seL4-kernel-riscv64-mcs
+    name: seL4-kernel-riscv64-mcs
     runs-on:
       - ubuntu-latest
     needs:
@@ -459,7 +459,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-riscv64-mcs --print-build-logs
   x86_64-linux---packages---seL4-kernel-x64:
-    name: x86_64-linux---packages---seL4-kernel-x64
+    name: seL4-kernel-x64
     runs-on:
       - ubuntu-latest
     needs:
@@ -478,7 +478,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-x64 --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-imx8mq-evk:
-    name: x86_64-linux---packages---seL4-test-aarch64-imx8mq-evk
+    name: seL4-test-aarch64-imx8mq-evk
     runs-on:
       - ubuntu-latest
     needs:
@@ -498,7 +498,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-imx8mq-evk --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-rpi4-1GB:
-    name: x86_64-linux---packages---seL4-test-aarch64-rpi4-1GB
+    name: seL4-test-aarch64-rpi4-1GB
     runs-on:
       - ubuntu-latest
     needs:
@@ -518,7 +518,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-rpi4-1GB --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-rpi4-2GB:
-    name: x86_64-linux---packages---seL4-test-aarch64-rpi4-2GB
+    name: seL4-test-aarch64-rpi4-2GB
     runs-on:
       - ubuntu-latest
     needs:
@@ -538,7 +538,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-rpi4-2GB --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-rpi4-4GB:
-    name: x86_64-linux---packages---seL4-test-aarch64-rpi4-4GB
+    name: seL4-test-aarch64-rpi4-4GB
     runs-on:
       - ubuntu-latest
     needs:
@@ -558,7 +558,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-rpi4-4GB --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-rpi4-8GB:
-    name: x86_64-linux---packages---seL4-test-aarch64-rpi4-8GB
+    name: seL4-test-aarch64-rpi4-8GB
     runs-on:
       - ubuntu-latest
     needs:
@@ -578,7 +578,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-rpi4-8GB --print-build-logs
   x86_64-linux---packages---seL4-test-aarch64-zcu102:
-    name: x86_64-linux---packages---seL4-test-aarch64-zcu102
+    name: seL4-test-aarch64-zcu102
     runs-on:
       - ubuntu-latest
     needs:
@@ -598,7 +598,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-aarch64-zcu102 --print-build-logs
   x86_64-linux---packages---seL4-test-armv7l-rpi3:
-    name: x86_64-linux---packages---seL4-test-armv7l-rpi3
+    name: seL4-test-armv7l-rpi3
     runs-on:
       - ubuntu-latest
     needs:
@@ -618,7 +618,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-armv7l-rpi3 --print-build-logs
   x86_64-linux---packages---seL4-test-armv7l-zynq7000:
-    name: x86_64-linux---packages---seL4-test-armv7l-zynq7000
+    name: seL4-test-armv7l-zynq7000
     runs-on:
       - ubuntu-latest
     needs:
@@ -638,7 +638,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-armv7l-zynq7000 --print-build-logs
   x86_64-linux---packages---seL4-test-armv7l-zynq7000-simulate:
-    name: x86_64-linux---packages---seL4-test-armv7l-zynq7000-simulate
+    name: seL4-test-armv7l-zynq7000-simulate
     runs-on:
       - ubuntu-latest
     needs:
@@ -658,7 +658,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-armv7l-zynq7000-simulate --print-build-logs
   x86_64-linux---packages---seL4-test-i686-ia32:
-    name: x86_64-linux---packages---seL4-test-i686-ia32
+    name: seL4-test-i686-ia32
     runs-on:
       - ubuntu-latest
     needs:
@@ -678,7 +678,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-i686-ia32 --print-build-logs
   x86_64-linux---packages---seL4-test-i686-ia32-simulate:
-    name: x86_64-linux---packages---seL4-test-i686-ia32-simulate
+    name: seL4-test-i686-ia32-simulate
     runs-on:
       - ubuntu-latest
     needs:
@@ -698,7 +698,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-i686-ia32-simulate --print-build-logs
   x86_64-linux---packages---seL4-test-x86_64-x86_64:
-    name: x86_64-linux---packages---seL4-test-x86_64-x86_64
+    name: seL4-test-x86_64-x86_64
     runs-on:
       - ubuntu-latest
     needs:
@@ -718,7 +718,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-x86_64-x86_64 --print-build-logs
   x86_64-linux---packages---seL4-test-x86_64-x86_64-simulate:
-    name: x86_64-linux---packages---seL4-test-x86_64-x86_64-simulate
+    name: seL4-test-x86_64-x86_64-simulate
     runs-on:
       - ubuntu-latest
     needs:
@@ -738,7 +738,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-x86_64-x86_64-simulate --print-build-logs
   x86_64-linux---packages---toolchain-aarch64-elf:
-    name: x86_64-linux---packages---toolchain-aarch64-elf
+    name: toolchain-aarch64-elf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -754,7 +754,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-aarch64-elf --print-build-logs
   x86_64-linux---packages---toolchain-aarch64-linux:
-    name: x86_64-linux---packages---toolchain-aarch64-linux
+    name: toolchain-aarch64-linux
     runs-on:
       - ubuntu-latest
     needs: []
@@ -770,7 +770,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-aarch64-linux --print-build-logs
   x86_64-linux---packages---toolchain-armv7l-eabihf:
-    name: x86_64-linux---packages---toolchain-armv7l-eabihf
+    name: toolchain-armv7l-eabihf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -786,7 +786,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-armv7l-eabihf --print-build-logs
   x86_64-linux---packages---toolchain-armv7l-linux:
-    name: x86_64-linux---packages---toolchain-armv7l-linux
+    name: toolchain-armv7l-linux
     runs-on:
       - ubuntu-latest
     needs: []
@@ -802,7 +802,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-armv7l-linux --print-build-logs
   x86_64-linux---packages---toolchain-i686-elf:
-    name: x86_64-linux---packages---toolchain-i686-elf
+    name: toolchain-i686-elf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -818,7 +818,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-i686-elf --print-build-logs
   x86_64-linux---packages---toolchain-riscv32-elf:
-    name: x86_64-linux---packages---toolchain-riscv32-elf
+    name: toolchain-riscv32-elf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -834,7 +834,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-riscv32-elf --print-build-logs
   x86_64-linux---packages---toolchain-riscv64-elf:
-    name: x86_64-linux---packages---toolchain-riscv64-elf
+    name: toolchain-riscv64-elf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -850,7 +850,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-riscv64-elf --print-build-logs
   x86_64-linux---packages---toolchain-x86_64-elf:
-    name: x86_64-linux---packages---toolchain-x86_64-elf
+    name: toolchain-x86_64-elf
     runs-on:
       - ubuntu-latest
     needs: []
@@ -866,7 +866,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-x86_64-elf --print-build-logs
   x86_64-linux---packages---uboot-aarch64-rpi4:
-    name: x86_64-linux---packages---uboot-aarch64-rpi4
+    name: uboot-aarch64-rpi4
     runs-on:
       - ubuntu-latest
     needs: []
@@ -882,7 +882,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.uboot-aarch64-rpi4 --print-build-logs
   x86_64-linux---packages---uboot-aarch64-zcu102:
-    name: x86_64-linux---packages---uboot-aarch64-zcu102
+    name: uboot-aarch64-zcu102
     runs-on:
       - ubuntu-latest
     needs: []
@@ -898,7 +898,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.uboot-aarch64-zcu102 --print-build-logs
   x86_64-linux---packages---uboot-armv7l-zynq-zc702:
-    name: x86_64-linux---packages---uboot-armv7l-zynq-zc702
+    name: uboot-armv7l-zynq-zc702
     runs-on:
       - ubuntu-latest
     needs: []
@@ -914,7 +914,7 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.uboot-armv7l-zynq-zc702 --print-build-logs
   x86_64-linux---devShells---default:
-    name: x86_64-linux---devShells---default
+    name: default
     runs-on:
       - ubuntu-latest
     needs:
@@ -935,7 +935,7 @@ jobs:
       - name: Build
         run: nix build .#devShells.x86_64-linux.default --print-build-logs
   x86_64-linux---devShells---microkit:
-    name: x86_64-linux---devShells---microkit
+    name: microkit
     runs-on:
       - ubuntu-latest
     needs:
@@ -953,7 +953,7 @@ jobs:
       - name: Build
         run: nix build .#devShells.x86_64-linux.microkit --print-build-logs
   x86_64-linux---checks---formatting:
-    name: x86_64-linux---checks---formatting
+    name: formatting
     runs-on:
       - ubuntu-latest
     needs: []

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -75,134 +75,6 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.concurrencytest --print-build-logs
-  x86_64-linux---packages---crossStdenvAarch64:
-    name: x86_64-linux---packages---crossStdenvAarch64
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvAarch64 --print-build-logs
-  x86_64-linux---packages---crossStdenvAarch64OldBintools:
-    name: x86_64-linux---packages---crossStdenvAarch64OldBintools
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvAarch64OldBintools --print-build-logs
-  x86_64-linux---packages---crossStdenvArmv7l:
-    name: x86_64-linux---packages---crossStdenvArmv7l
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvArmv7l --print-build-logs
-  x86_64-linux---packages---crossStdenvArmv7lOldBintools:
-    name: x86_64-linux---packages---crossStdenvArmv7lOldBintools
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvArmv7lOldBintools --print-build-logs
-  x86_64-linux---packages---crossStdenvRiscv32:
-    name: x86_64-linux---packages---crossStdenvRiscv32
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvRiscv32 --print-build-logs
-  x86_64-linux---packages---crossStdenvRiscv64:
-    name: x86_64-linux---packages---crossStdenvRiscv64
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvRiscv64 --print-build-logs
-  x86_64-linux---packages---crossStdenvi686:
-    name: x86_64-linux---packages---crossStdenvi686
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvi686 --print-build-logs
-  x86_64-linux---packages---crossStdenvx86_64:
-    name: x86_64-linux---packages---crossStdenvx86_64
-    runs-on:
-      - ubuntu-latest
-    needs: []
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v14
-        with:
-          name: dlr-ft
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build
-        run: nix build .#packages.x86_64-linux.crossStdenvx86_64 --print-build-logs
   x86_64-linux---packages---guardonce:
     name: x86_64-linux---packages---guardonce
     runs-on:
@@ -309,10 +181,10 @@ jobs:
       - x86_64-linux---packages---camkes-deps
       - x86_64-linux---packages---capDL-tool
       - x86_64-linux---packages---concurrencytest
-      - x86_64-linux---packages---crossStdenvAarch64OldBintools
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -332,10 +204,10 @@ jobs:
       - x86_64-linux---packages---camkes-deps
       - x86_64-linux---packages---capDL-tool
       - x86_64-linux---packages---concurrencytest
-      - x86_64-linux---packages---crossStdenvAarch64OldBintools
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -355,10 +227,10 @@ jobs:
       - x86_64-linux---packages---camkes-deps
       - x86_64-linux---packages---capDL-tool
       - x86_64-linux---packages---concurrencytest
-      - x86_64-linux---packages---crossStdenvAarch64OldBintools
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -378,10 +250,10 @@ jobs:
       - x86_64-linux---packages---camkes-deps
       - x86_64-linux---packages---capDL-tool
       - x86_64-linux---packages---concurrencytest
-      - x86_64-linux---packages---crossStdenvAarch64OldBintools
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -401,10 +273,10 @@ jobs:
       - x86_64-linux---packages---camkes-deps
       - x86_64-linux---packages---capDL-tool
       - x86_64-linux---packages---concurrencytest
-      - x86_64-linux---packages---crossStdenvArmv7lOldBintools
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-armv7l-eabihf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -479,6 +351,7 @@ jobs:
     needs:
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
+      - x86_64-linux---packages---seL4-deps
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -547,8 +420,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-kernel-arm-mcs --print-build-logs
-  x86_64-linux---packages---seL4-kernel-riscv64:
-    name: x86_64-linux---packages---seL4-kernel-riscv64
+  x86_64-linux---packages---seL4-kernel-riscv64-elf:
+    name: x86_64-linux---packages---seL4-kernel-riscv64-elf
     runs-on:
       - ubuntu-latest
     needs:
@@ -565,7 +438,7 @@ jobs:
           name: dlr-ft
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
-        run: nix build .#packages.x86_64-linux.seL4-kernel-riscv64 --print-build-logs
+        run: nix build .#packages.x86_64-linux.seL4-kernel-riscv64-elf --print-build-logs
   x86_64-linux---packages---seL4-kernel-riscv64-mcs:
     name: x86_64-linux---packages---seL4-kernel-riscv64-mcs
     runs-on:
@@ -609,10 +482,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -629,10 +502,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -649,10 +522,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -669,10 +542,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -689,10 +562,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -709,10 +582,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvAarch64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-aarch64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -729,10 +602,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvArmv7l
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-armv7l-eabihf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -749,10 +622,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvArmv7l
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-armv7l-eabihf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -769,10 +642,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvArmv7l
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-armv7l-eabihf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -789,10 +662,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvi686
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-i686-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -809,10 +682,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvi686
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-i686-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -829,10 +702,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvx86_64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-x86_64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -849,10 +722,10 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---packages---crossStdenvx86_64
       - x86_64-linux---packages---guardonce
       - x86_64-linux---packages---pyfdt
       - x86_64-linux---packages---seL4-deps
+      - x86_64-linux---packages---toolchain-x86_64-elf
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -864,6 +737,134 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.seL4-test-x86_64-x86_64-simulate --print-build-logs
+  x86_64-linux---packages---toolchain-aarch64-elf:
+    name: x86_64-linux---packages---toolchain-aarch64-elf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-aarch64-elf --print-build-logs
+  x86_64-linux---packages---toolchain-aarch64-linux:
+    name: x86_64-linux---packages---toolchain-aarch64-linux
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-aarch64-linux --print-build-logs
+  x86_64-linux---packages---toolchain-armv7l-eabihf:
+    name: x86_64-linux---packages---toolchain-armv7l-eabihf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-armv7l-eabihf --print-build-logs
+  x86_64-linux---packages---toolchain-armv7l-linux:
+    name: x86_64-linux---packages---toolchain-armv7l-linux
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-armv7l-linux --print-build-logs
+  x86_64-linux---packages---toolchain-i686-elf:
+    name: x86_64-linux---packages---toolchain-i686-elf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-i686-elf --print-build-logs
+  x86_64-linux---packages---toolchain-riscv32-elf:
+    name: x86_64-linux---packages---toolchain-riscv32-elf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-riscv32-elf --print-build-logs
+  x86_64-linux---packages---toolchain-riscv64-elf:
+    name: x86_64-linux---packages---toolchain-riscv64-elf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-riscv64-elf --print-build-logs
+  x86_64-linux---packages---toolchain-x86_64-elf:
+    name: x86_64-linux---packages---toolchain-x86_64-elf
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-x86_64-elf --print-build-logs
   x86_64-linux---packages---uboot-aarch64-rpi4:
     name: x86_64-linux---packages---uboot-aarch64-rpi4
     runs-on:

--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,10 @@
         ### Custom cross-compilation Environments
         #
         pkgsCross = nixpkgs.lib.attrsets.genAttrs [
-          "aarch64-unknown-none-elf"
           "aarch64-unknown-linux-gnu"
-          "armv7l-unknown-none-eabihf"
+          "aarch64-unknown-none-elf"
           "armv7l-unknown-linux-gnueabihf"
+          "armv7l-unknown-none-eabihf"
           "i686-unknown-none-elf"
           "microblazeel-none-elf"
           "riscv32-unknown-none-elf"

--- a/patches/seL4-compile-musl-on-recent-gcc-1.patch
+++ b/patches/seL4-compile-musl-on-recent-gcc-1.patch
@@ -1,0 +1,26 @@
+From 29d041ae7c9d0afd312f77c11a737fab2a371d2c Mon Sep 17 00:00:00 2001
+From: Alwin Joshy <joshyalwin@gmail.com>
+Date: Thu, 15 Aug 2024 16:32:59 +1000
+Subject: [PATCH] hack: provide __getauxval()
+
+Signed-off-by: Alwin Joshy <joshyalwin@gmail.com>
+---
+ src/misc/getauxval.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/misc/getauxval.c b/src/misc/getauxval.c
+index b846c80fd..c1134492b 100644
+--- a/src/misc/getauxval.c
++++ b/src/misc/getauxval.c
+@@ -2,6 +2,11 @@
+ #include <errno.h>
+ #include "libc.h"
+ 
++unsigned long __getauxval(unsigned long type) {
++    errno = ENOENT;
++    return 0;
++}
++
+ unsigned long getauxval(unsigned long item)
+ {
+ 	size_t *auxv = libc.auxv;

--- a/patches/seL4-compile-musl-on-recent-gcc-2.patch
+++ b/patches/seL4-compile-musl-on-recent-gcc-2.patch
@@ -1,0 +1,185 @@
+From 41e4ef7776c1ab8e3f8d7d597f26f8fbef38e0da Mon Sep 17 00:00:00 2001
+From: Alwin Joshy <joshyalwin@gmail.com>
+Date: Wed, 14 Aug 2024 18:17:35 +1000
+Subject: [PATCH] hack: allow musllibc to compile with gcc >= 12
+
+Signed-off-by: Alwin Joshy <joshyalwin@gmail.com>
+---
+ include/features.h        | 11 +++++++++++
+ include/stdio.h           | 18 ++++++++++++++++++
+ src/internal/stdio_impl.h |  4 ++++
+ src/stdio/stderr.c        | 27 +++++++++++++++------------
+ src/stdio/stdin.c         | 25 ++++++++++++++-----------
+ src/stdio/stdout.c        | 28 ++++++++++++++++------------
+ 6 files changed, 78 insertions(+), 35 deletions(-)
+
+diff --git a/include/features.h b/include/features.h
+index f4d651efc..ac5c2f25b 100644
+--- a/include/features.h
++++ b/include/features.h
+@@ -36,3 +36,14 @@
+ #endif
+ 
+ #endif
++
++#ifndef FEATURES_H
++#define FEATURES_H
++
++// #define weak __attribute__((__weak__))
++#define hidden __attribute__((__visibility__("hidden")))
++/*
++#define weak_alias(old, new) \
++       extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
++*/
++#endif
+\ No newline at end of file
+diff --git a/include/stdio.h b/include/stdio.h
+index 884d2e6a7..a92fcc248 100644
+--- a/include/stdio.h
++++ b/include/stdio.h
+@@ -201,3 +201,21 @@ int fputs_unlocked(const char *, FILE *);
+ #endif
+ 
+ #endif
++
++
++#ifndef STDIO_H
++#define STDIO_H
++
++#undef stdin
++#undef stdout
++#undef stderr
++
++extern hidden FILE __stdin_FILE;
++extern hidden FILE __stdout_FILE;
++extern hidden FILE __stderr_FILE;
++
++#define stdin (&__stdin_FILE)
++#define stdout (&__stdout_FILE)
++#define stderr (&__stderr_FILE)
++
++#endif
+diff --git a/src/internal/stdio_impl.h b/src/internal/stdio_impl.h
+index 7cdf729de..433a71f72 100644
+--- a/src/internal/stdio_impl.h
++++ b/src/internal/stdio_impl.h
+@@ -50,6 +50,10 @@ struct _IO_FILE {
+ 	struct __locale_struct *locale;
+ };
+ 
++extern hidden FILE *volatile __stdin_used;
++extern hidden FILE *volatile __stdout_used;
++extern hidden FILE *volatile __stderr_used;
++
+ size_t __stdio_read(FILE *, unsigned char *, size_t);
+ size_t __stdio_write(FILE *, const unsigned char *, size_t);
+ size_t __stdout_write(FILE *, const unsigned char *, size_t);
+diff --git a/src/stdio/stderr.c b/src/stdio/stderr.c
+index 229c8651d..e837cdfa0 100644
+--- a/src/stdio/stderr.c
++++ b/src/stdio/stderr.c
+@@ -1,16 +1,19 @@
+ #include "stdio_impl.h"
++#include "features.h"
++
++#undef stderr
+ 
+ static unsigned char buf[UNGET];
+-static FILE f = {
+-	.buf = buf+UNGET,
+-	.buf_size = 0,
+-	.fd = 2,
+-	.flags = F_PERM | F_NORD,
+-	.lbf = -1,
+-	.write = __stdio_write,
+-	.seek = __stdio_seek,
+-	.close = __stdio_close,
+-	.lock = -1,
++hidden FILE __stderr_FILE  = {
++        .buf = buf+UNGET,
++        .buf_size = 0,
++        .fd = 2,
++        .flags = F_PERM | F_NORD,
++        .lbf = -1,
++        .write = __stdio_write,
++        .seek = __stdio_seek,
++        .close = __stdio_close,
++        .lock = -1,
+ };
+-FILE *const stderr = &f;
+-FILE *volatile __stderr_used = &f;
++FILE *const stderr = &__stderr_FILE;
++FILE *volatile __stderr_used = &__stderr_FILE;
+\ No newline at end of file
+diff --git a/src/stdio/stdin.c b/src/stdio/stdin.c
+index 171ff22a9..3655871c7 100644
+--- a/src/stdio/stdin.c
++++ b/src/stdio/stdin.c
+@@ -1,15 +1,18 @@
+ #include "stdio_impl.h"
++#include "features.h"
++
++#undef stdin
+ 
+ static unsigned char buf[BUFSIZ+UNGET];
+-static FILE f = {
+-	.buf = buf+UNGET,
+-	.buf_size = sizeof buf-UNGET,
+-	.fd = 0,
+-	.flags = F_PERM | F_NOWR,
+-	.read = __stdio_read,
+-	.seek = __stdio_seek,
+-	.close = __stdio_close,
+-	.lock = -1,
++hidden FILE __stdin_FILE  = {
++        .buf = buf+UNGET,
++        .buf_size = sizeof buf-UNGET,
++        .fd = 0,
++        .flags = F_PERM | F_NOWR,
++        .read = __stdio_read,
++        .seek = __stdio_seek,
++        .close = __stdio_close,
++        .lock = -1,
+ };
+-FILE *const stdin = &f;
+-FILE *volatile __stdin_used = &f;
++FILE *const stdin = &__stdin_FILE;
++FILE *volatile __stdin_used = &__stdin_FILE;
+\ No newline at end of file
+diff --git a/src/stdio/stdout.c b/src/stdio/stdout.c
+index 6b188942d..85268d2e4 100644
+--- a/src/stdio/stdout.c
++++ b/src/stdio/stdout.c
+@@ -1,16 +1,20 @@
+ #include "stdio_impl.h"
++#include "features.h"
++
++#undef stdout
+ 
+ static unsigned char buf[BUFSIZ+UNGET];
+-static FILE f = {
+-	.buf = buf+UNGET,
+-	.buf_size = sizeof buf-UNGET,
+-	.fd = 1,
+-	.flags = F_PERM | F_NORD,
+-	.lbf = '\n',
+-	.write = __stdout_write,
+-	.seek = __stdio_seek,
+-	.close = __stdio_close,
+-	.lock = -1,
++hidden FILE __stdout_FILE = {
++        .buf = buf+UNGET,
++        .buf_size = sizeof buf-UNGET,
++        .fd = 1,
++        .flags = F_PERM | F_NORD,
++        .lbf = '\n',
++        .write = __stdout_write,
++        .seek = __stdio_seek,
++        .close = __stdio_close,
++        .lock = -1,
+ };
+-FILE *const stdout = &f;
+-FILE *volatile __stdout_used = &f;
++
++FILE *const stdout = &__stdout_FILE;
++FILE *volatile __stdout_used = &__stdout_FILE;

--- a/pkgs/seL4-test.nix
+++ b/pkgs/seL4-test.nix
@@ -59,6 +59,12 @@ stdenvNoLibs.mkDerivation rec {
     popd
   '';
 
+  # Fix for https://github.com/seL4/sel4test/issues/127
+  # Gcc compiling for an x86 -elf target treats single forward slashed (`/`) as
+  # beginning of comments, which breaks the alignment tests in
+  # projects/sel4test/apps/sel4test-tests/src/arch/x86/tests/alignment_asm.S
+  env.NIX_CFLAGS_COMPILE = lib.strings.optionalString (stdenvNoLibs.hostPlatform.isx86) "-Wa,--divide";
+
   # prevent Nix from injecting any flags meant to harden the build
   hardeningDisable = [ "all" ];
 


### PR DESCRIPTION
This refactors the seL4-test and the seL4-camkes-vm-examples pkgs, so that the old musllibc is patched to work even with modern bintools!