### PR TITLE
feat: add opensbi-cva6 expression

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -124,6 +124,22 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.microkit-sdk --print-build-logs
+  x86_64-linux---packages---opensbi-riscv64-cva6:
+    name: opensbi-riscv64-cva6
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.opensbi-riscv64-cva6 --print-build-logs
   x86_64-linux---packages---pmufw-mblaze-zcu102:
     name: pmufw-mblaze-zcu102
     runs-on:
@@ -849,6 +865,22 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix build .#packages.x86_64-linux.toolchain-riscv64-elf --print-build-logs
+  x86_64-linux---packages---toolchain-riscv64-linux:
+    name: toolchain-riscv64-linux
+    runs-on:
+      - ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build
+        run: nix build .#packages.x86_64-linux.toolchain-riscv64-linux --print-build-logs
   x86_64-linux---packages---toolchain-x86_64-elf:
     name: toolchain-x86_64-elf
     runs-on:

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
           "i686-unknown-none-elf"
           "microblazeel-none-elf"
           "riscv32-unknown-none-elf"
+          "riscv64-unknown-linux-gnu"
           "riscv64-unknown-none-elf"
           "x86_64-unknown-none-elf"
         ]
@@ -50,6 +51,7 @@
           toolchain-i686-elf = pkgsCross.i686-unknown-none-elf.stdenvNoLibs;
           toolchain-riscv32-elf = pkgsCross.riscv32-unknown-none-elf.stdenvNoLibs;
           toolchain-riscv64-elf = pkgsCross.riscv64-unknown-none-elf.stdenvNoLibs;
+          toolchain-riscv64-linux = pkgsCross.riscv64-unknown-linux-gnu.stdenvNoLibs;
           toolchain-x86_64-elf = pkgsCross.x86_64-unknown-none-elf.stdenvNoLibs;
 
 
@@ -335,6 +337,18 @@
           #
           ### Firmware
           #
+          opensbi-riscv64-cva6 = (pkgsCross.riscv64-unknown-linux-gnu.opensbi.overrideAttrs
+            (_: {
+              src = pkgs.fetchFromGitHub {
+                owner = "riscv-software-src";
+                repo = "opensbi";
+                rev = "be245acfffa297b5ed4e0c7bb473a6bd55231bf8";
+                hash = "sha256-EtG5MgeeAo7Lw0XkvcDonpIhSmb/1Y4GnA2/DB8yCJg=";
+              };
+              env.NIX_CFLAGS_COMPILE = "-march=rv64imafdc_zicsr_zifencei";
+            }));
+
+
           pmufw-mblaze-zcu102 = pkgsCross.microblazeel-none-elf.callPackage ./pkgs/xilinx-pmufw.nix { };
 
 


### PR DESCRIPTION
It might be helpful when deploying seL4/microkit for the Ariane RISC-V CPU.