### PR TITLE
fix: add `extraCmakeFlags` arg to seL4-kernel.nix

### DIFF
--- a/pkgs/seL4-kernel.nix
+++ b/pkgs/seL4-kernel.nix
@@ -10,6 +10,7 @@
 , python3Packages
 , verifiedConfig ? null
 , extraVerifiedConfigs ? [ ]
+, extraCmakeFlags ? [ ]
 }:
 
 
@@ -62,7 +63,8 @@ stdenv.mkDerivation rec {
     "-GNinja"
     "-DCROSS_COMPILER_PREFIX=${stdenv.cc.targetPrefix}"
     "-DCMAKE_TOOLCHAIN_FILE=../gcc.cmake"
-  ] ++ lib.lists.optional (verifiedConfig != null) "-C../configs/${verifiedConfig}.cmake";
+  ] ++ lib.lists.optional (verifiedConfig != null) "-C../configs/${verifiedConfig}.cmake"
+  ++ extraCmakeFlags;
 
   # TODO remove hotfix for https://github.com/seL4/seL4/issues/1334
   patches = lib.lists.optional (lib.lists.elem verifiedConfig brokenVerifiedConfigs) ../patches/seL4-cmake-install-target-failure.patch;


### PR DESCRIPTION
This fixes #41. Thank you @nspin for spotting this :smile: 